### PR TITLE
Fixing a typo in the homepage

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -667,7 +667,7 @@
         </p>
       </section>
       <aside class="color-names">
-        <h2>Color Properies</h2>
+        <h2>Color Properties</h2>
         <div data-names></div>
       </aside>
     </article>


### PR DESCRIPTION
Changed "properies" to "properties"